### PR TITLE
Fix velociraptor startup

### DIFF
--- a/Vagrant/logger_bootstrap.sh
+++ b/Vagrant/logger_bootstrap.sh
@@ -466,6 +466,8 @@ install_velociraptor() {
   cp /vagrant/resources/velociraptor/server.config.yaml /opt/velociraptor
   echo "[$(date +%H:%M:%S)]: Creating Velociraptor dpkg..."
   ./velociraptor --config /opt/velociraptor/server.config.yaml debian server
+  echo "[$(date +%H:%M:%S)]: Cleanup velociraptor package building leftovers..."
+  rm -rf /opt/velociraptor/logs
   echo "[$(date +%H:%M:%S)]: Installing the dpkg..."
   if dpkg -i velociraptor_*_server.deb >/dev/null; then
     echo "[$(date +%H:%M:%S)]: Installation complete!"


### PR DESCRIPTION
Cleanup the velociraptor package building leftovers

The dpkg creation of velociraptor creates log files owned by root, preventing velociraptor from starting afterwards. Delete the logs folder and let the initial velociraptor startup handle the rest.