### PR TITLE
Make dhcp disable for eth1 working after reboot

### DIFF
--- a/Vagrant/logger_bootstrap.sh
+++ b/Vagrant/logger_bootstrap.sh
@@ -95,7 +95,7 @@ fix_eth1_static_ip() {
     fi
   fi
   # TODO: try to set correctly directly through vagrant net config
-  netplan set ethernets.eth1.dhcp4=false
+  netplan set --origin-hint 90-disable-eth1-dhcp ethernets.eth1.dhcp4=false
   netplan apply
 
   # Fix eth1 if the IP isn't set correctly


### PR DESCRIPTION
vagrant will override its default configuration on every "vagrant up", so we put our override in a separate file with higher precedence.